### PR TITLE
fix: automerge workflow event condition

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
   automerge:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- The automerge workflow checks `github.event.workflow_run.event == 'pull_request'`, but the Node.js Package workflow triggers on `push` events
- This means the automerge condition is never satisfied and dependabot PRs are never auto-merged
- Fix: change the condition to check for `push` instead of `pull_request`

## Test plan
- [ ] Verify automerge workflow runs are no longer skipped when dependabot PRs pass CI

Generated with [Claude Code](https://claude.com/claude-code)