### PR TITLE
fix: preserve undo by stubbing window.confirm instead of replacing the click handler

### DIFF
--- a/static/js/init.js
+++ b/static/js/init.js
@@ -1,15 +1,32 @@
 'use strict';
 
-exports.postAceInit = (hook, context) => {
-  $('.buttonicon-clearauthorship').parent().parent().off('click'); // remove pre-existing events
-  $('.buttonicon-clearauthorship').parent().parent().click(() => { // add new click event handler
-    context.ace.callWithAce((ace) => { // call the function to apply the attribute inside ACE
-      if ((!(ace.ace_getRep().selStart && ace.ace_getRep().selEnd)) || ace.ace_isCaret()) {
-        ace.ace_performDocumentApplyAttributesToCharRange(
-            0, ace.ace_getRep().alltext.length, [['author', '']]);
-      } else {
-        ace.ace_setAttributeOnSelection('author', '');
-      }
-    }, 'clearAuthorship', true);
-  });
+// Don't prompt for confirmation when the user clicks "Clear authorship colors".
+//
+// Earlier revisions of this plugin replaced the editbar's click handler
+// with a direct `ace.callWithAce(... performDocumentApplyAttributesToCharRange
+// ..., 'clearAuthorship', true)` call. That bypassed core's clearauthorship
+// command-call-stack (registered in pad_editbar.ts via `registerAceCommand`),
+// which is what records the operation in the undo history. Result: the
+// clear happened, but undo no longer restored authorship — breaking
+// clear_authorship_color.spec.ts:38 and undo_clear_authorship.spec.ts.
+//
+// Cleaner approach: leave core's handler intact and intercept the click
+// in the capture phase to neutralise just the `window.confirm` call.
+// Core then proceeds through the normal `ace_performDocumentApplyAttributesToCharRange`
+// path inside its proper undo-aware call stack.
+//
+// We restore window.confirm right after the bubble-phase click runs so
+// other confirm prompts in the pad UI (import overwrite, delete pad) are
+// untouched.
+exports.postAceInit = () => {
+  const li = $('.buttonicon-clearauthorship').parent().parent()[0];
+  if (!li) return;
+  li.addEventListener('click', () => {
+    const original = window.confirm;
+    window.confirm = () => true;
+    // Restore on the next microtask — long enough for core's bubble-phase
+    // click handler (which calls window.confirm synchronously) to see the
+    // stub, short enough that no later confirm dialog catches it.
+    Promise.resolve().then(() => { window.confirm = original; });
+  }, true /* capture phase: runs before core's bubble-phase handler */);
 };


### PR DESCRIPTION
## Why

The old implementation `.off('click')`'d the editbar's clearauthorship button and replaced it with a fresh handler that called:

```js
ace.callWithAce((ace) => {
  ace.ace_performDocumentApplyAttributesToCharRange(0, ..., [['author', '']]);
}, 'clearAuthorship', true);
```

That bypassed core's clearauthorship command-call-stack (registered via `registerAceCommand` in [`pad_editbar.ts:540`](https://github.com/ether/etherpad-lite/blob/develop/src/static/js/pad_editbar.ts#L540)), which is what records the operation in the undo history. Visible effect: clearing worked, but undo no longer restored authorship.

This broke three core specs:
- `clear_authorship_color.spec.ts:38 — clear authorship colors can be undone to restore author colors`
- `undo_clear_authorship.spec.ts:32 — User B should not be disconnected after undoing clear authorship`
- `undo_clear_authorship.spec.ts:104 — single user can undo clear authorship without disconnect`

## Fix

Leave core's handler intact. Intercept the click in the **capture** phase to neutralise just the `window.confirm` call. Core then proceeds through its normal `ace_performDocumentApplyAttributesToCharRange` path *inside* its proper undo-aware call stack — so undo works again.

`window.confirm` is restored on the next microtask so other confirm prompts in the pad UI (import overwrite, delete pad) are unaffected.

## Verified

Ran the affected specs locally with the fixed plugin installed:

```
✓  1 clear authorship color (1.1s)
✓  2 clear authorship colors can be undone to restore author colors (1.1s)
✓  3 clears authorship when first line has line attributes (1.2s)
✓  4 User B should not be disconnected after undoing clear authorship (5.1s)
✓  5 single user can undo clear authorship without disconnect (1.2s)
5 passed (10.5s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)